### PR TITLE
Removed bogus min/max scale check

### DIFF
--- a/source/TreeLoader2D.cpp
+++ b/source/TreeLoader2D.cpp
@@ -78,8 +78,6 @@ void TreeLoader2D::addTree(Entity *entity, const Vector3 &position, Degree yaw, 
 	const Real smallVal = 0.01f;
 	if (pos.x < actualBounds.left-smallVal || pos.x > actualBounds.right+smallVal || pos.z < actualBounds.top-smallVal || pos.z > actualBounds.bottom+smallVal)
 		OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Tree position is out of bounds", "TreeLoader::addTree()");
-	if (scale < minimumScale || scale > maximumScale)
-		OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Tree scale out of range", "TreeLoader::addTree()");
 	#endif
 
 	//If the tree is slightly out of bounds (due to imprecise coordinate conversion), fix it

--- a/source/TreeLoader3D.cpp
+++ b/source/TreeLoader3D.cpp
@@ -73,8 +73,6 @@ void TreeLoader3D::addTree(Entity *entity, const Ogre::Vector3 &position, Degree
 	const Real smallVal = 0.01f;
 	if (pos.x < actualBounds.left-smallVal || pos.x > actualBounds.right+smallVal || pos.z < actualBounds.top-smallVal || pos.z > actualBounds.bottom+smallVal)
 		OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Tree position is out of bounds", "TreeLoader::addTree()");
-	if (scale < minimumScale || scale > maximumScale)
-		OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Tree scale out of range", "TreeLoader::addTree()");
 	#endif
 
 	//If the tree is slightly out of bounds (due to imprecise coordinate conversion), fix it


### PR DESCRIPTION
The parameters are a scale conversion range rather than scale limit range.

A lot of Rigs of Rods content uses scale values larger than the built-in maximum, triggering error in debug builds.